### PR TITLE
fix: handle runtimes longer than three hours

### DIFF
--- a/helpers/humanize-runtime.ts
+++ b/helpers/humanize-runtime.ts
@@ -1,15 +1,10 @@
 const humanizeRuntime = (amount: number) => {
   if (!amount) return "Unknown";
-  if (amount < 60) {
-    return `0h ${amount}m`;
-  }
-  if (amount < 120) {
-    return `1h ${amount - 60}m`;
-  }
-  if (amount < 180) {
-    return `2h ${amount - 120}m`;
-  }
-  return `3h ${amount - 180}m`;
+
+  const hours = Math.floor(amount / 60);
+  const minutes = amount % 60;
+
+  return `${hours}h ${minutes}m`;
 };
 
 export default humanizeRuntime;


### PR DESCRIPTION
## Summary
- calculate hours and minutes dynamically in `humanizeRuntime`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `node -e "const h=require('/tmp/humanize/humanize-runtime.js').default; console.log('240 ->', h(240)); console.log('59 ->', h(59));"`


------
https://chatgpt.com/codex/tasks/task_b_688b180a07f4832a8810cc1207952830